### PR TITLE
Fixed C++ linking support

### DIFF
--- a/files/libwav.h
+++ b/files/libwav.h
@@ -5,6 +5,9 @@
 // http://soundfile.sapp.org/doc/WaveFormat/
 // https://wiki.fileformat.com/audio/wav/
 
+#include <sys/cdefs.h>
+__BEGIN_DECLS
+
 #include <stdio.h>
 
 #define	WAVE_FORMAT_PCM     	0x0001  // PCM
@@ -23,5 +26,7 @@ typedef struct {
 
 int wav_get_info_file(FILE* file, WavFileInfo* result);
 int wav_get_info_buffer(const unsigned char* buffer, WavFileInfo* result);
+
+__END_DECLS
 
 #endif

--- a/files/sndwav.h
+++ b/files/sndwav.h
@@ -1,6 +1,9 @@
 #ifndef SNDWAV_H
 #define SNDWAV_H
 
+#include <sys/cdefs.h>
+__BEGIN_DECLS
+
 #include <stdio.h>
 
 #define STREAM_BUFFER_SIZE 65536
@@ -24,5 +27,7 @@ int wav_isplaying(wav_stream_hnd_t hnd);
 
 void wav_add_filter(wav_stream_hnd_t hnd, wav_filter filter, void* obj);
 void wav_remove_filter(wav_stream_hnd_t hnd, wav_filter filter, void* obj);
+
+__END_DECLS
 
 #endif


### PR DESCRIPTION
Without `__BEGIN_DECLS` and `__END_DECLS`, the C++ compiler will mangle the function names and fail to link. With those added, when using a C++ compiler, it will automatically wrap the declarations in `extern "C" { }` which prevents the mangling, but will not insert anything when using a C compiler (this is used in all of the other kos-ports sound libraries to allow C++ support).