### PR TITLE
Add include for kos/mutex.h in sndwav.c

### DIFF
--- a/sndwav.c
+++ b/sndwav.c
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <malloc.h>
 
+#include <kos/mutex.h>
 #include <kos/thread.h>
 #include <dc/sound/stream.h>
 


### PR DESCRIPTION
`sndwav.c` uses `mutex_t`, `MUTEX_INITIALIZER`, `mutex_lock()`, and `mutex_unlock()` without `#include`ing `<kos/mutex.h>`. This doesn't seem to be a problem most of the time since the header is still being included from somewhere else, but on branches of KOS using the (not yet merged) `libpthread` addon, this is no longer the case, causing a build failure:

```
sndwav.c:72:8: error: unknown type name ‘mutex_t’
   72 | static mutex_t stream_mutex = MUTEX_INITIALIZER;
      |        ^~~~~~~
sndwav.c:72:31: error: ‘MUTEX_INITIALIZER’ undeclared here (not in a function); did you mean ‘TRACEBUF_INITIALIZER’?
   72 | static mutex_t stream_mutex = MUTEX_INITIALIZER;
      |                               ^~~~~~~~~~~~~~~~~
      |                               TRACEBUF_INITIALIZER
sndwav.c: In function ‘wav_destroy’:
sndwav.c:117:5: error: implicit declaration of function ‘mutex_lock’ [-Wimplicit-function-declaration]
  117 |     mutex_lock(&stream_mutex);
      |     ^~~~~~~~~~
sndwav.c:133:5: error: implicit declaration of function ‘mutex_unlock’ [-Wimplicit-function-declaration]
  133 |     mutex_unlock(&stream_mutex);
      |     ^~~~~~~~~~~~
make[1]: *** [/opt/toolchains/dc/kos/Makefile.rules:14: sndwav.o] Error 1
make[1]: Leaving directory '/opt/toolchains/dc/kos-ports/libwav/build/libwav-1.0.0'
make: *** [/opt/toolchains/dc/kos-ports/scripts/build.mk:35: build-stamp] Error 2
```

This PR simply adds an `#include` for the header.