### PR TITLE
Fix stream replay volume restoration

### DIFF
--- a/sndwav.c
+++ b/sndwav.c
@@ -296,6 +296,7 @@ void wav_play(wav_stream_hnd_t hnd) {
     if(streams[hnd].status == SNDDEC_STATUS_STREAMING)
        return;
 
+    snd_stream_volume(streams[hnd].shnd, streams[hnd].vol);
     streams[hnd].status = SNDDEC_STATUS_RESUMING;
 }
 


### PR DESCRIPTION
Ensure that when a stream is replayed after being stopped or paused, it resumes at the volume level set prior to stopping/pausing.